### PR TITLE
Demo for `between()`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,6 +71,24 @@ class="nat-gap  nat-md-gap-50" </pre>
     }
 }</pre>
 
+        <div>window.innerWidth: <span id="innerWidth"></span></div>
+        <script type="module">
+            const element = document.getElementById('innerWidth');
+            function update() {
+                element.innerText = window.visualViewport.width;
+            }
+
+            window.onresize = update
+            update();
+        </script>
+
+        <div class="test nat-horizontal">
+            <div class="between-xs-sm">xs-sm</div>
+            <div class="between-sm-md">sm-md</div>
+            <div class="between-md-lg">md-lg</div>
+            <div class="between-lg-xl">lg-xl</div>
+        </div>
+
         <h1>Unresponsive html markup</h1>
 
         <h2 id="section-padding">nat-padding</h2>

--- a/src/_main.scss
+++ b/src/_main.scss
@@ -7,3 +7,28 @@
 html {
     --natural-default-spacing: 20px;
 }
+
+// TODO uncomment this and make it work (and move all .between* inside the doc, probably)
+//.between-xs-sm {
+//    @include mixins.between(xs, sm) {
+//        background-color: green;
+//    }
+//}
+
+.between-sm-md {
+    @include mixins.between(sm, md) {
+        background-color: green !important;
+    }
+}
+
+.between-md-lg {
+    @include mixins.between(md, lg) {
+        background-color: green !important;
+    }
+}
+
+.between-lg-xl {
+    @include mixins.between(lg, xl) {
+        background-color: green !important;
+    }
+}


### PR DESCRIPTION
C'est draft, parce que `.between-xs-sm` n'est pas fonctionnel. Et parce que tous les `.between-*` devrait probablement vivre dans la doc, et pas dans la lib. Mais je sais pas comment tu voulais t'organiser pour cela. Du coup je te laisse faire.

![image](https://github.com/Ecodev/natural-layout/assets/72603/445e09a0-1d25-4e84-8d59-c7d12a94c3e9)
